### PR TITLE
Better user feedback upon a successful verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: haskell/actions/setup@v1
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc-version }}

--- a/copilot-verifier-demo/src/Demo1.hs
+++ b/copilot-verifier-demo/src/Demo1.hs
@@ -27,6 +27,6 @@ main :: IO ()
 main = do
   interpret 6 spec
 
-  -- spec' <- reify spec
+  spec' <- reify spec
   -- compile "demo1" spec'
-  -- verify mkDefaultCSettings [] "demo1" spec'
+  verifyWithOptions defaultVerifierOptions{verbosity = Noisy} mkDefaultCSettings [] "demo1" spec'


### PR DESCRIPTION
Upon a successful run of the verifier, we now print out a general description of what `copilot-verifier` did, along with brief explanations of what the various proof goals indicate. This should make it easier to interpret the results if you are not an expert in formal verification.
    
We also print out a suggestion to turn the verbosity to `Noisy` if you want a more detailed look into what each proof goal means.