### PR TITLE
Log when proof goals arise before or after calling `step()`. Refs #52.

### DIFF
--- a/copilot-verifier/CHANGELOG
+++ b/copilot-verifier/CHANGELOG
@@ -1,3 +1,7 @@
+2024-07-18
+        * When using `Noisy` verbosity, log more information about which proof
+          goals arise before or after calling the `step()` function. (#52)
+
 2024-07-11
         * Version bump (3.20). (#58)
 


### PR DESCRIPTION
In particular, proof goals that arise when checking the state relation can arise pre- or post-`step()`, so we make a note of this when logging the proof goals and report it to the user.

Fixes #52.