### PR TITLE
Better distinguish between durable and non-durable proof goals. Refs #51.

### DIFF
--- a/copilot-verifier/CHANGELOG
+++ b/copilot-verifier/CHANGELOG
@@ -1,4 +1,6 @@
-2024-07-18
+2024-07-30
+        * When using `Noisy` verbosity, always log proof goals related to the
+          core correspondence proof, even if the goals are trivial. (#51)
         * When using `Noisy` verbosity, log more information about which proof
           goals arise before or after calling the `step()` function. (#52)
 


### PR DESCRIPTION
Previously, the verifier was inconsistent about whether it would log certain types of proof goals. As discussed in https://github.com/Copilot-Language/copilot-verifier/issues/51, there are really two types of proof goals:

1. Goals that the verifier asserts directly as part of the correspondence proof.
2. Goals that arise during symbolic execution of the `step()` function to ensure memory safety.

We always want to log goals of type (1), as they are core to the correspondence proof that the verifier is computing. Due to the sheer volume of goals of type (2), however, we only want to log type-(2) goals if they are non-trivial (i.e., not just the `true` predicate in `what4`).

This patch:

* Ensures that all type-(1) goals are asserting using Crucible's _durable_ assertions so that they will always be logged, even if they are trivial.
* Makes the verifier's logs distinguish between the two types of goals when the `Noisy` verbosity level is chosen.

Fixes #51.