### PR TITLE
Reject multiple triggers with the same name. Refs #74.

### DIFF
--- a/copilot-verifier/CHANGELOG
+++ b/copilot-verifier/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-20
+        * Reject specs that use multiple triggers with the same name. (#74)
+
 2024-11-08
         * Version bump (4.1). (#72)
 


### PR DESCRIPTION
Although `copilot-c99` added the ability to invoke multiple triggers with the same name in https://github.com/Copilot-Language/copilot/pull/572, it is not yet clear how best to support this in `copilot-verifier`.

In the meantime, this adds an explicit check that rules out specifications that use multiple triggers with the same name to prevent the verifier from becoming confused by them. The remaining task of fully supporting such specifications is tracked in https://github.com/Copilot-Language/copilot-verifier/issues/74.