### PR TITLE
Add `smtSolver` option to `VerifierOptions`. Refs #78.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ prerequisites:
 * Ensure that you have the `z3` SMT solver in your `PATH`. `z3` binaries are
   available at https://github.com/Z3Prover/z3/releases.
 
+  Alternatively, the verifier can be configured to use one of the following
+  SMT solvers instead:
+
+  * `cvc4`: https://cvc4.github.io/downloads.html
+  * `cvc5`: https://github.com/cvc5/cvc5/releases/
+  * `yices`: https://yices.csl.sri.com
+
 Then, clone the repo and run:
 
 ```

--- a/copilot-verifier/CHANGELOG
+++ b/copilot-verifier/CHANGELOG
@@ -1,3 +1,6 @@
+2025-01-31
+        * Add `smtSolver` option to `VerifierOptions`. (#78)
+
 2025-01-20
         * Version bump (4.2). (#76)
         * Reject specs that use multiple triggers with the same name. (#74)

--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -71,6 +71,7 @@ library
   exposed-modules:
     Copilot.Verifier
     Copilot.Verifier.Log
+    Copilot.Verifier.Solver
 
 library copilot-verifier-examples
   import: bldflags

--- a/copilot-verifier/src/Copilot/Verifier/Solver.hs
+++ b/copilot-verifier/src/Copilot/Verifier/Solver.hs
@@ -1,0 +1,25 @@
+module Copilot.Verifier.Solver
+  ( Solver(..)
+  , solverAdapter
+  ) where
+
+import qualified What4.Solver.Adapter as W4
+import qualified What4.Solver.CVC4 as W4.CVC4
+import qualified What4.Solver.CVC5 as W4.CVC5
+import qualified What4.Solver.Yices as W4.Yices
+import qualified What4.Solver.Z3 as W4.Z3
+
+-- | General-purpose SMT solvers that @copilot-verifier@ supports.
+data Solver
+  = CVC4
+  | CVC5
+  | Yices
+  | Z3
+  deriving Show
+
+-- | Return the @what4@ 'W4.SolverAdapter' corresponding to a given 'Solver'.
+solverAdapter :: Solver -> W4.SolverAdapter st
+solverAdapter CVC4  = W4.CVC4.cvc4Adapter
+solverAdapter CVC5  = W4.CVC5.cvc5Adapter
+solverAdapter Yices = W4.Yices.yicesAdapter
+solverAdapter Z3    = W4.Z3.z3Adapter


### PR DESCRIPTION
This allows users to switch between the CVC4, CVC5, Yices, and Z3 SMT solvers, depending on which solver is the most appropriate for a given task. The default solver is Z3, as before.

Fixes #78.