### PR TITLE
Add `smtFloatMode` option to `VerifierOptions`. Refs #79.

### DIFF
--- a/copilot-verifier/CHANGELOG
+++ b/copilot-verifier/CHANGELOG
@@ -1,5 +1,6 @@
-2025-01-31
+2025-02-03
         * Add `smtSolver` option to `VerifierOptions`. (#78)
+        * Add `smtFloatMode` option to `VerifierOptions`. (#79)
 
 2025-01-20
         * Version bump (4.2). (#76)

--- a/copilot-verifier/copilot-verifier.cabal
+++ b/copilot-verifier/copilot-verifier.cabal
@@ -70,6 +70,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Copilot.Verifier
+    Copilot.Verifier.FloatMode
     Copilot.Verifier.Log
     Copilot.Verifier.Solver
 
@@ -81,6 +82,7 @@ library copilot-verifier-examples
     case-insensitive,
     copilot >= 4.2 && < 4.3,
     copilot-language >= 4.2 && < 4.3,
+    copilot-libraries >= 4.2 && < 4.3,
     copilot-prettyprinter >= 4.2 && < 4.3,
     copilot-verifier
   exposed-modules:
@@ -104,6 +106,7 @@ library copilot-verifier-examples
     Copilot.Verifier.Examples.ShouldPass.Clock
     Copilot.Verifier.Examples.ShouldPass.Counter
     Copilot.Verifier.Examples.ShouldPass.Engine
+    Copilot.Verifier.Examples.ShouldPass.FPNegation
     Copilot.Verifier.Examples.ShouldPass.FPOps
     Copilot.Verifier.Examples.ShouldPass.Heater
     Copilot.Verifier.Examples.ShouldPass.IntOps

--- a/copilot-verifier/examples/Copilot/Verifier/Examples.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples.hs
@@ -28,6 +28,7 @@ import qualified Copilot.Verifier.Examples.ShouldPass.Arith                    a
 import qualified Copilot.Verifier.Examples.ShouldPass.Clock                    as Clock
 import qualified Copilot.Verifier.Examples.ShouldPass.Counter                  as Counter
 import qualified Copilot.Verifier.Examples.ShouldPass.Engine                   as Engine
+import qualified Copilot.Verifier.Examples.ShouldPass.FPNegation               as FPNegation
 import qualified Copilot.Verifier.Examples.ShouldPass.FPOps                    as FPOps
 import qualified Copilot.Verifier.Examples.ShouldPass.Heater                   as Heater
 import qualified Copilot.Verifier.Examples.ShouldPass.IntOps                   as IntOps
@@ -70,6 +71,7 @@ shouldPassExamples verb = Map.fromList
     , example "Clock" (Clock.verifySpec verb)
     , example "Counter" (Counter.verifySpec verb)
     , example "Engine" (Engine.verifySpec verb)
+    , example "FPNegation" (FPNegation.verifySpec verb)
     , example "FPOps" (FPOps.verifySpec verb)
     , example "Heater" (Heater.verifySpec verb)
     , example "IntOps" (IntOps.verifySpec verb)

--- a/copilot-verifier/examples/Copilot/Verifier/Examples/ShouldPass/FPNegation.hs
+++ b/copilot-verifier/examples/Copilot/Verifier/Examples/ShouldPass/FPNegation.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | This will not succeed when 'smtFloatMode' is 'FloatUninterpreted', as Clang
+-- will turn @input /= 30.0@ below into a more complicated expression that also
+-- checks if @30.0@ is NaN or not. This is logically equivalent to the original
+-- specification, but an SMT solver cannot conclude this when all of the
+-- floating-point operations involved are treated as uninterpreted functions.
+--
+-- To make this work, we set 'smtFloatMode' to 'FloatIEEE' instead. This works
+-- because all of the floating-point operations in the specification below are
+-- native to SMT-LIB.
+module Copilot.Verifier.Examples.ShouldPass.FPNegation where
+
+import Copilot.Compile.C99 (mkDefaultCSettings)
+import Copilot.Verifier ( Verbosity, VerifierOptions(..)
+                        , defaultVerifierOptions, verifyWithOptions )
+import Copilot.Verifier.FloatMode (FloatMode(..))
+import qualified Copilot.Library.PTLTL as PTLTL
+import Language.Copilot
+
+input :: Stream Float
+input = extern "input" Nothing
+
+-- | MyProperty
+--   @
+--   Input is never 30.0
+--   @
+propMyProperty :: Stream Bool
+propMyProperty = PTLTL.alwaysBeen (input /= 30.0)
+
+-- | Clock that increases in one-unit steps.
+clock :: Stream Int64
+clock = [0] ++ (clock + 1)
+
+-- | First Time Point
+ftp :: Stream Bool
+ftp = [True] ++ false
+
+pre :: Stream Bool -> Stream Bool
+pre = ([False] ++)
+
+tpre :: Stream Bool -> Stream Bool
+tpre = ([True] ++)
+
+notPreviousNot :: Stream Bool -> Stream Bool
+notPreviousNot = not . PTLTL.previous . not
+
+-- | Complete specification. Calls C handler functions when properties are
+-- violated.
+spec :: Spec
+spec = do
+  trigger "handlerMyProperty" (not propMyProperty) []
+
+verifySpec :: Verbosity -> IO ()
+verifySpec verb = do
+  spec' <- reify spec
+  verifyWithOptions
+    (defaultVerifierOptions
+      { verbosity = verb
+      , smtFloatMode = FloatIEEE
+      })
+    mkDefaultCSettings [] "fpNegation" spec'

--- a/copilot-verifier/src/Copilot/Verifier/FloatMode.hs
+++ b/copilot-verifier/src/Copilot/Verifier/FloatMode.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Copilot.Verifier.FloatMode
+  ( FloatMode(..)
+  , withFloatMode
+  , withInterpretedFloatExprBuilder
+  ) where
+
+import qualified What4.Expr.Builder as W4
+import qualified What4.InterpretedFloatingPoint as W4
+
+-- | How the verifier should interpret floating-point operations.
+data FloatMode
+  = -- | Floating-point values are treated as bitvectors of the appropriate
+    -- width, and all operations on them are translated as uninterpreted
+    -- functions. This is the verifier's default interpretation, and it is what
+    -- allows the verifier to perform any reasoning at all over floating-point
+    -- operations that are not native to SMT-LIB (@sin@, @cos@, @tan@, etc.).
+    FloatUninterpreted
+
+  | -- | Floating-point values are treated as bit-precise IEEE-754 floats. This
+    -- interpretation can perform deeper reasoning about floating-point
+    -- operations that are native to SMT-LIB, but at the expense of causing the
+    -- verifier to throw an error if it encounters operations that are not
+    -- native to SMT-LIB (@sin@, @cos@, @tan@, etc.). Use at your own risk.
+    FloatIEEE
+  deriving Show
+
+-- | Convert a 'FloatMode' into a What4 'W4.FloatModeRepr' and pass it to a
+-- continuation.
+withFloatMode ::
+  FloatMode ->
+  (forall fm. W4.FloatModeRepr fm -> r) ->
+  r
+withFloatMode fm k =
+  case fm of
+    FloatUninterpreted ->
+      k W4.FloatUninterpretedRepr
+    FloatIEEE ->
+      k W4.FloatIEEERepr
+
+-- | Match on a 'W4.FloatModeRepr', compute evidence that it gives rise to an
+-- instance of 'W4.IsInterpretedFloatExprBuilder', and pass the evidence to a
+-- continutation.
+withInterpretedFloatExprBuilder ::
+  W4.ExprBuilder t st (W4.Flags fm) ->
+  W4.FloatModeRepr fm ->
+  (W4.IsInterpretedFloatExprBuilder (W4.ExprBuilder t st (W4.Flags fm)) => r) ->
+  r
+withInterpretedFloatExprBuilder _sym fm k =
+  case fm of
+    W4.FloatUninterpretedRepr -> k
+    W4.FloatIEEERepr -> k
+    W4.FloatRealRepr -> k


### PR DESCRIPTION
This allows users to switch between `FloatUninterpreted` (the default setting, where all floating-point operations are treated as uninterpreted functions) and `FloatIEEE` (where floating-point values are treated as IEEE-754 floats). While `FloatIEEE` is unable to handle floating-point operations that are not native to SMT-LIB (`sin`, `cos`, `tan`, etc.), it can handle more specifications in which a C compiler optimizes the floating-point expressions found in the generated C code. An example of where this is crucible can be found in the newly added `FPNegation` example, which was inspired by Ogma.

Fixes #79.